### PR TITLE
display search result with a tree

### DIFF
--- a/build/scripts/script.js
+++ b/build/scripts/script.js
@@ -479,6 +479,9 @@ function initializeSearchEngine() {
   return searchState.promise;
 }
 
+// Symbol are guaranteed to be unique.
+// So there will be no overlap between this symbol or any string
+// when it's used as a key to access an object property.
 const __DEFAULT_SYMBOL__ = Symbol("__DEFAULT__");
 
 /**

--- a/build/scripts/script.js
+++ b/build/scripts/script.js
@@ -519,60 +519,20 @@ function updateSearchResults(value) {
       '<div class="message">' + "No result for that search." + "</div>";
     return;
   }
+
+  // only consider the first 30 results
+  const searchResultSlice = searchResults.slice(0, 29);
+  const searchResultSorted = reorderSearchResultByGroup(searchResultSlice);
   searchResultsElt.innerHTML = "";
 
-  for (let resIdx = 0; resIdx < searchResults.length && resIdx < 30; resIdx++) {
-    const res = searchResults[resIdx];
-    const links = searchIndexLinks[+res.refIndex];
+  for (const res of searchResultSorted) {
+    const links = searchIndexLinks[+res.ref];
     const contentDiv = document.createElement("div");
     contentDiv.className = "search-result-item";
-
     const locationDiv = document.createElement("div");
     locationDiv.className = "search-result-location";
-
-    let needSeparator = false;
-    if (res.item.h1 !== undefined && res.item.h1 !== "") {
-      let linkH1;
-      if (links.anchorH1 !== undefined) {
-        const href = rootUrl + "/" + links.file + "#" + links.anchorH1;
-        linkH1 = document.createElement("a");
-        linkH1.href = href;
-      } else {
-        linkH1 = document.createElement("span");
-      }
-      linkH1.className = "h1";
-      linkH1.textContent = res.item.h1;
-      locationDiv.appendChild(linkH1);
-      needSeparator = true;
-    }
-
-    if (res.item.h2 !== undefined && res.item.h2 !== "") {
-      if (needSeparator) {
-        const separatorSpan = document.createElement("span");
-        separatorSpan.textContent = " > ";
-        locationDiv.appendChild(separatorSpan);
-        needSeparator = false;
-      }
-      let linkH2;
-      if (links.anchorH2 !== undefined) {
-        const href = rootUrl + "/" + links.file + "#" + links.anchorH2;
-        linkH2 = document.createElement("a");
-        linkH2.href = href;
-      } else {
-        linkH2 = document.createElement("span");
-      }
-      linkH2.className = "h2";
-      linkH2.textContent = res.item.h2;
-      locationDiv.appendChild(linkH2);
-      needSeparator = true;
-    }
-    if (res.item.h3 !== undefined && res.item.h3 !== "") {
-      if (needSeparator) {
-        const separatorSpan = document.createElement("span");
-        separatorSpan.textContent = " > ";
-        locationDiv.appendChild(separatorSpan);
-        needSeparator = false;
-      }
+    if (res.doc.h3 !== undefined && res.doc.h3 !== "") {
+      contentDiv.classList.add("search-result-item-is-h3");
       let linkH3;
       if (links.anchorH3 !== undefined) {
         const href = rootUrl + "/" + links.file + "#" + links.anchorH3;
@@ -582,12 +542,39 @@ function updateSearchResults(value) {
         linkH3 = document.createElement("span");
       }
       linkH3.className = "h3";
-      linkH3.textContent = res.item.h3;
+      linkH3.textContent = res.doc.h3;
       locationDiv.appendChild(linkH3);
+    } else if (res.doc.h2 !== undefined && res.doc.h2 !== "") {
+      contentDiv.classList.add("search-result-item-is-h2");
+      let linkH2;
+      if (links.anchorH2 !== undefined) {
+        const href = rootUrl + "/" + links.file + "#" + links.anchorH2;
+        linkH2 = document.createElement("a");
+        linkH2.href = href;
+      } else {
+        linkH2 = document.createElement("span");
+      }
+      linkH2.className = "h2";
+      linkH2.textContent = res.doc.h2;
+      locationDiv.appendChild(linkH2);
+    } else if (res.doc.h1 !== undefined && res.doc.h1 !== "") {
+      contentDiv.classList.add("search-result-item-is-h1");
+      let linkH1;
+      if (links.anchorH1 !== undefined) {
+        const href = rootUrl + "/" + links.file + "#" + links.anchorH1;
+        linkH1 = document.createElement("a");
+        linkH1.href = href;
+      } else {
+        linkH1 = document.createElement("span");
+      }
+      linkH1.className = "h1";
+      linkH1.textContent = res.doc.h1;
+      locationDiv.appendChild(linkH1);
     }
+
     const bodyDiv = document.createElement("div");
     bodyDiv.className = "search-result-body";
-    let body = res.item.body ?? "";
+    let body = res.doc.body ?? "";
     if (body.length > 300) {
       body = body.substring(0, 300) + "...";
     }
@@ -597,6 +584,113 @@ function updateSearchResults(value) {
     contentDiv.appendChild(bodyDiv);
     searchResultsElt.appendChild(contentDiv);
   }
+}
+
+/**
+ * Add missing top sections headers (h1) in search results.
+ * Search result can be h1, h2 or h3, but the search algorithm can
+ * find a match for a h3 section and not for the h1.
+ * To not display h3 orphan in the tree view, we manually to
+ * the search result the h1 that is a parent to that h3.
+ * @param {array} searchResults
+ * @returns
+ */
+function addMissingTopSections(searchResults) {
+  const h1Sections = {};
+  const missingH1 = [];
+  for (result of searchResults) {
+    if (!h1Sections[result.doc.h1]) {
+      h1Sections[result.doc.h1] = [];
+    }
+    h1Sections[result.doc.h1].push(result);
+  }
+
+  for (const value of Object.values(h1Sections)) {
+    const topSection = value.find((r) => {
+      return r.doc.h2 === undefined;
+    });
+    if (topSection === undefined) {
+      const fakeH1 = structuredClone(value[0]);
+      fakeH1.doc.h2 = undefined;
+      fakeH1.doc.h3 = undefined;
+      fakeH1.doc.body = "";
+      missingH1.push(fakeH1);
+    }
+  }
+  return searchResults.concat(missingH1);
+}
+
+/**
+ * Re-orders search results by grouping them according
+ * to their shared section headings (h1, h2, h3).
+ * @param {array} searchResults The array of search results to be re-ordered.
+ * @returns An array re-ordered based on section headings.
+ *
+ * @example
+ */
+function reorderSearchResultByGroup(searchResults) {
+  const results = addMissingTopSections(searchResults);
+
+  // group by h1
+  const groupedSearchResult = groupArrayItemsBy(results, (item) => item.doc.h1);
+  // group by h2
+  for (let i = 0; i < groupedSearchResult.length; i++) {
+    // item with no h2 should be ordered before items with h2.
+    sortUndefinedPropertyFirst(groupedSearchResult[i], (item) => item.doc.h2);
+    groupedSearchResult[i] = groupArrayItemsBy(
+      groupedSearchResult[i],
+      (item) => item.doc.h2,
+    );
+    // group by h3
+    for (let j = 0; j < groupedSearchResult[i].length; j++) {
+      // item with no h3 should be ordered before items with h3.
+      sortUndefinedPropertyFirst(
+        groupedSearchResult[i][j],
+        (item) => item.doc.h3,
+      );
+      groupedSearchResult[i][j] = groupArrayItemsBy(
+        groupedSearchResult[i][j],
+        (item) => item.doc.h3,
+      );
+    }
+  }
+  return groupedSearchResult.flat(3);
+}
+
+/**
+ * Groups items in an array based on a property and returns an array of subarrays.
+ * @param {array} array The array to group.
+ * @param {function} accessor A function that returns the property value to group by.
+ * @returns An array of subarrays containing items grouped by the specified property.
+ *
+ * @example
+ * const arr = [{ foo: 1, bar: 2}, { foo: 1, bar: 3}, { foo: 2, bar: 2}];
+ * groupArrayItemsBy(arr, (item) => item.foo);
+ * // Returns: [[{ foo: 1, bar: 2}, { foo: 1, bar: 3 }], [{ foo: 2, bar: 2 }]]
+ */
+function groupArrayItemsBy(array, accessor) {
+  const groupedItems = [];
+  const groups = {};
+
+  array.forEach((item) => {
+    const key = accessor(item);
+    if (!groups[key]) {
+      groups[key] = [];
+      groupedItems.push(groups[key]);
+    }
+    groups[key].push(item);
+  });
+
+  return groupedItems;
+}
+
+/**
+ * Sorts an array by placing elements with the specified property undefined at the beginning.
+ * @param {array} array
+ * @param {function} accessor
+ */
+function sortUndefinedPropertyFirst(array, accessor) {
+  array.sort((a, b) => (accessor(a) === undefined ? -1 : 1));
 }
 
 /**

--- a/build/scripts/script.js
+++ b/build/scripts/script.js
@@ -544,17 +544,11 @@ function updateSearchResults(value) {
 }
 
 /**
- * Compares two search result items to determine the deepest common ancestor based on their properties.
- *
- * The comparison order is:
- * 1. `file` - If files don't match, return 3.
- * 2. `h1` - If `file` matches but `h1` doesn't, return 2.
- * 3. `h2` - If both `file` and `h1` match but `h2` doesn't, return 1.
- * 4. If all properties match, return 0 (indicating the deepest common ancestor).
+ * Compares two search result items to determine the deepest common ancestor level.
  *
  * @param {Object} itemA - The first search result item.
  * @param {Object} itemB - The second search result item.
- * @returns {number} - Returns 3 if `file` differs, 2 if `h1` differs, 1 if `h2` differs, or 0 if all properties match.
+ * @returns {number} - Returns 0 if items does not share same file, 1 if h1 is different, etc...
  */
 function getCommonAncestorLevel(searchResultItemA, searchResultItemB) {
   if (searchResultItemA.file !== searchResultItemB.file) {

--- a/build/scripts/script.js
+++ b/build/scripts/script.js
@@ -570,42 +570,6 @@ function getCommonAncestorLevel(searchResultItemA, searchResultItemB) {
 }
 
 /**
- * Add missing top sections headers (h1) in search results.
- * Search result can be h1, h2 or h3, but the search algorithm can
- * find a match for a h3 section and not for the h1.
- * To not display h3 orphan in the tree view, we manually add to
- * the search result the h1 that is a parent to that h3.
- * @param {array} searchResults
- * @returns
- */
-function addMissingTopSections(searchResults) {
-  const h1Sections = {};
-  const missingH1 = [];
-  for (result of searchResults) {
-    const keyName = `${result.item.file}-${result.item.h1}`;
-    if (!h1Sections[keyName]) {
-      h1Sections[keyName] = [];
-    }
-    h1Sections[keyName].push(result);
-  }
-
-  console.log("Search result", JSON.parse(JSON.stringify(searchResults)));
-  for (const value of Object.values(h1Sections)) {
-    const topSection = value.find((r) => {
-      return r.item.h2 === undefined && r.item.h3;
-    });
-    if (topSection === undefined) {
-      const fakeH1 = structuredClone(value[0]);
-      fakeH1.item.h2 = undefined;
-      fakeH1.item.h3 = undefined;
-      fakeH1.item.body = "";
-      missingH1.push(fakeH1);
-    }
-  }
-  return searchResults.concat(missingH1);
-}
-
-/**
  * Re-orders search results by grouping them according
  * to their shared section headings (h1, h2, h3).
  * @param {array} searchResults The array of search results to be re-ordered.

--- a/build/scripts/script.js
+++ b/build/scripts/script.js
@@ -479,6 +479,8 @@ function initializeSearchEngine() {
   return searchState.promise;
 }
 
+const __DEFAULT_SYMBOL__ = Symbol("__DEFAULT__");
+
 /**
  * Update search result in the search result HTMLElement according to the given
  * value.
@@ -528,21 +530,21 @@ function updateSearchResults(value) {
 
   for (const file of Object.values(searchResultSorted)) {
     for (const h1 of Object.values(file)) {
-      if (h1.__DEFAULT__) {
-        const elem = createResultElement(h1.__DEFAULT__);
+      if (h1[__DEFAULT_SYMBOL__]) {
+        const elem = createResultElement(h1[__DEFAULT_SYMBOL__]);
         searchResultsElt.appendChild(elem);
       }
       for (const [keyH2, valueH2] of Object.entries(h1)) {
-        if (keyH2 === "__DEFAULT__") {
+        if (keyH2 === __DEFAULT_SYMBOL__) {
           continue;
         }
-        if (valueH2.__DEFAULT__) {
-          const elem = createResultElement(valueH2.__DEFAULT__);
+        if (valueH2[__DEFAULT_SYMBOL__]) {
+          const elem = createResultElement(valueH2[__DEFAULT_SYMBOL__]);
           searchResultsElt.appendChild(elem);
         }
 
         for (const [keyH3, valueH3] of Object.entries(valueH2)) {
-          if (keyH3 === "__DEFAULT__") {
+          if (keyH3 === __DEFAULT_SYMBOL__) {
             continue;
           }
           valueH3.forEach((val) => {
@@ -606,7 +608,6 @@ function reorderSearchResultByGroup(searchResults) {
 
   return groupedSearchResult;
 }
-
 /**
  * Groups items in an array based on their h1, h2 and h3 titles.
  * @param {array} array The array to group.
@@ -640,27 +641,18 @@ function groupItems(results) {
         grouping[item.file][item.h1][item.h2][item.h3].push(item);
       } else {
         // If no h3, use '__DEFAULT__'
-        if (!grouping[item.file][item.h1][item.h2]["__DEFAULT__"]) {
-          grouping[item.file][item.h1][item.h2]["__DEFAULT__"] = item;
+        if (!grouping[item.file][item.h1][item.h2][__DEFAULT_SYMBOL__]) {
+          grouping[item.file][item.h1][item.h2][__DEFAULT_SYMBOL__] = item;
         }
       }
     } else {
       // If no h2, use '__DEFAULT__' under h1
-      if (!grouping[item.file][item.h1]["__DEFAULT__"]) {
-        grouping[item.file][item.h1]["__DEFAULT__"] = item;
+      if (!grouping[item.file][item.h1][__DEFAULT_SYMBOL__]) {
+        grouping[item.file][item.h1][__DEFAULT_SYMBOL__] = item;
       }
     }
   });
   return grouping;
-}
-
-/**
- * Sorts an array by placing elements with the specified property undefined at the beginning.
- * @param {array} array
- * @param {function} accessor
- */
-function sortUndefinedPropertyFirst(array, accessor) {
-  array.sort((a, b) => (accessor(a) === undefined ? -1 : 1));
 }
 
 /**

--- a/build/scripts/script.js
+++ b/build/scripts/script.js
@@ -568,10 +568,11 @@ function addMissingTopSections(searchResults) {
   const h1Sections = {};
   const missingH1 = [];
   for (result of searchResults) {
-    if (!h1Sections[result.item.h1]) {
-      h1Sections[result.item.h1] = [];
+    const keyName = `${result.item.file}-${result.item.h1}`;
+    if (!h1Sections[keyName]) {
+      h1Sections[keyName] = [];
     }
-    h1Sections[result.item.h1].push(result);
+    h1Sections[keyName].push(result);
   }
 
   for (const value of Object.values(h1Sections)) {

--- a/build/scripts/script.js
+++ b/build/scripts/script.js
@@ -563,9 +563,6 @@ function getCommonAncestorLevel(searchResultItemA, searchResultItemB) {
     return 2;
   }
 
-  if (searchResultItemA.h3 !== searchResultItemB.h3) {
-    return 3;
-  }
   return 3;
 }
 
@@ -597,7 +594,7 @@ function groupItems(results) {
     let item = res.item;
 
     if (item.file === undefined || item.h1 === undefined) {
-      // item.file and item.h1 is required, if it's missing let's skeep the search result.
+      // item.file and item.h1 is required, if it's missing let's skip the search result.
       return;
     }
     if (!groupedByFileAndHeader[item.file]) {
@@ -621,7 +618,7 @@ function groupItems(results) {
         }
         groupedByFileAndHeader[item.file][item.h1][item.h2][item.h3].push(item);
       } else {
-        // If no h3, use '__DEFAULT__'
+        // If no h3, use the default symbol
         if (
           !groupedByFileAndHeader[item.file][item.h1][item.h2][
             __DEFAULT_SYMBOL__
@@ -629,14 +626,18 @@ function groupItems(results) {
         ) {
           groupedByFileAndHeader[item.file][item.h1][item.h2][
             __DEFAULT_SYMBOL__
-          ] = [item];
+          ] = [];
         }
+        groupedByFileAndHeader[item.file][item.h1][item.h2][
+          __DEFAULT_SYMBOL__
+        ].push(item);
       }
     } else {
-      // If no h2, use '__DEFAULT__' under h1
+      // If no h2, use the default symbol under h1
       if (!groupedByFileAndHeader[item.file][item.h1][__DEFAULT_SYMBOL__]) {
-        groupedByFileAndHeader[item.file][item.h1][__DEFAULT_SYMBOL__] = [item];
+        groupedByFileAndHeader[item.file][item.h1][__DEFAULT_SYMBOL__] = [];
       }
+      groupedByFileAndHeader[item.file][item.h1][__DEFAULT_SYMBOL__].push(item);
     }
   });
   return groupedByFileAndHeader;

--- a/build/styles/style.css
+++ b/build/styles/style.css
@@ -222,6 +222,25 @@ table tr td {
   margin: 17px 0px;
 }
 
+.search-result-item-is-h2 {
+  padding-left: 40px;
+}
+
+.search-result-item-is-h3 {
+  padding-left: 80px;
+}
+
+.search-result-item-is-h1 .search-result-location::before {
+  content: "📄";
+  padding-right: 8px;
+}
+
+.search-result-item-is-h2 .search-result-location::before,
+.search-result-item-is-h3 .search-result-location::before {
+  content: "#️";
+  padding-right: 8px;
+}
+
 #search-results {
   margin-top: 20px;
   padding-bottom: 20px;

--- a/src/create_documentation_page.ts
+++ b/src/create_documentation_page.ts
@@ -120,7 +120,7 @@ export default async function createDocumentationPage({
     tocMd,
     nbTocElements,
   } = await parseMD(data, inputDir, outputDir, baseOutDir, linkTranslator);
-  const searchData = getSearchDataForContent(resHtml);
+  const searchData = getSearchDataForContent(resHtml, outputUrlFromRoot);
   searchIndex.push({
     file: outputUrlFromRoot,
     index: searchData,

--- a/src/get_search_data_for_content.ts
+++ b/src/get_search_data_for_content.ts
@@ -2,6 +2,7 @@ import type { AnyNode } from "cheerio";
 import { load } from "cheerio";
 
 export interface FileSearchIndex {
+  fileURL: string;
   h1: string | undefined;
   h2?: string | undefined;
   h3?: string | undefined;
@@ -18,6 +19,7 @@ export interface FileSearchIndex {
  */
 export default function getSearchDataForContent(
   contentHtml: string,
+  fileURL: string,
 ): FileSearchIndex[] {
   const indexForFile: FileSearchIndex[] = [];
   const $ = load(contentHtml);
@@ -87,6 +89,7 @@ export default function getSearchDataForContent(
     if (currentLevel === "h3") {
       const body = currentBody.length > 0 ? currentBody.join(" ") : "";
       indexForFile.push({
+        fileURL,
         h1: currentH1,
         h2: currentH2,
         h3: currentH3,
@@ -98,6 +101,7 @@ export default function getSearchDataForContent(
     } else if (currentLevel === "h2") {
       const body = currentBody.length > 0 ? currentBody.join(" ") : "";
       indexForFile.push({
+        fileURL,
         h1: currentH1,
         h2: currentH2,
         body,
@@ -107,6 +111,7 @@ export default function getSearchDataForContent(
     } else if (currentLevel === "h1") {
       const body = currentBody.length > 0 ? currentBody.join(" ") : "";
       indexForFile.push({
+        fileURL,
         h1: currentH1,
         body,
         anchorH1: currentH1Anchor,


### PR DESCRIPTION
The idea of this proposal is to display results with a tree when searching on the doc.


<img width="1786" alt="image" src="https://github.com/canalplus/README/assets/58945185/b7633491-846c-4991-93c9-895454510d68">

There is an issue if the search result include a subsection but not the parent section, in this case the subsection is orphan, I'm not sure how to handle that.