### PR TITLE
feat: add sitemap generation

### DIFF
--- a/doc/.docConfig.json
+++ b/doc/.docConfig.json
@@ -29,5 +29,6 @@
     {
       "type": "version"
     }
-  ]
+  ],
+  "siteMapRoot": "https://peaberberian.github.io/README/doc/"
 }

--- a/doc/Getting_Started/Steps/Configuration.md
+++ b/doc/Getting_Started/Steps/Configuration.md
@@ -110,7 +110,11 @@ properties indicated as "optional" can be omitted:
       // Can be ignored in which case the version is not clickable
       "link": "https://example.com/documentation_pages_by_version.html",
     }
-  ]
+  ],
+  // Optional string that specifies the base URL that would be used when generating
+  // the sitemap.xml file. 
+  // If not defined, the generation of the sitemap.xml file will be omitted.
+  "siteMapRoot": "https://example.com/"
 }
 ```
 

--- a/src/parse_doc_configs.ts
+++ b/src/parse_doc_configs.ts
@@ -54,6 +54,7 @@ interface RootDocConfigInput {
   };
   linksLeft?: unknown[];
   linksRight?: unknown[];
+  siteMapRoot?: string;
 }
 
 interface InnerDocConfigInput {
@@ -93,6 +94,7 @@ export interface ParsedDocConfig {
       };
   links: LinkCategory[];
   linksRightIndex: number;
+  siteMapRoot: undefined | string;
 }
 
 export default async function parseDocConfigs(
@@ -106,6 +108,7 @@ export default async function parseDocConfigs(
     favicon: undefined,
     links: [],
     linksRightIndex: -1,
+    siteMapRoot: undefined,
   };
 
   if (typeof rootConfig.logo === "object") {
@@ -215,6 +218,10 @@ export default async function parseDocConfigs(
     if (parsedCategory !== undefined) {
       ret.links.push(parsedCategory);
     }
+  }
+
+  if (typeof rootConfig.siteMapRoot === "string") {
+    ret.siteMapRoot = rootConfig.siteMapRoot;
   }
   return ret;
 }
@@ -407,6 +414,12 @@ async function parseAndCheckRootConfigFile(
   if ("linksRight" in config && !Array.isArray(config.linksRight)) {
     exitWithInvalidRootConfig(
       `The "linksRight" property, if defined, should be set as an Array.`,
+    );
+  }
+
+  if ("siteMapRoot" in config && typeof config.siteMapRoot !== "string") {
+    exitWithInvalidRootConfig(
+      `The "siteMapRoot" property, if defined, should be a string.`,
     );
   }
 

--- a/src/site_map_creator.ts
+++ b/src/site_map_creator.ts
@@ -43,12 +43,31 @@ export class SiteMapCreator {
     ${this.siteMapEntry
       .map(
         (entry) => `<url>
-      <loc>${entry.loc}</loc>
-      <lastmod>${entry.lastmod}</lastmod>
+      <loc>${escapeXml(entry.loc)}</loc>
+      <lastmod>${escapeXml(entry.lastmod)}</lastmod>
     </url>
     `,
       )
       .join("")}
   </urlset>`;
   }
+}
+
+function escapeXml(unsafe: string) {
+  return unsafe.replace(/[<>&'"]/g, (c: string) => {
+    switch (c) {
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case "&":
+        return "&amp;";
+      case "'":
+        return "&apos;";
+      case '"':
+        return "&quot;";
+      default:
+        return "";
+    }
+  });
 }

--- a/src/site_map_creator.ts
+++ b/src/site_map_creator.ts
@@ -1,0 +1,54 @@
+/**
+ * Class responsible for creating and managing a sitemap.
+ * It allows adding URLs to the sitemap and generating an XML file of the sitemap.
+ * This is used by search engines to crawl and index files.
+ */
+export class SiteMapCreator {
+  /**
+   * @private
+   * @type {Array<{ loc: string, lastmod: string }>}
+   * @description Stores the list of URLs and their corresponding last modified dates.
+   */
+  private siteMapEntry: Array<{ loc: string; lastmod: string }>;
+
+  constructor() {
+    this.siteMapEntry = [];
+  }
+
+  /**
+   * Adds a new URL to the sitemap.
+   * The `lastmod` (last modification date) is automatically set to the current date in the format `YYYY-MM-DD`.
+   *
+   * @param {string} loc - The URL to be added to the sitemap.
+   * @example
+   * const sitemap = new SiteMapCreator();
+   * sitemap.addToSiteMap('https://mydoc.com');
+   */
+  public addToSiteMap(loc: string) {
+    this.siteMapEntry.push({
+      loc,
+      lastmod: new Date().toISOString().split("T")[0],
+    });
+  }
+
+  /**
+   * Generates the XML for the sitemap.
+   * This method converts the list of entries into a properly formatted XML string.
+   *
+   * @returns {string} The XML string representing the sitemap.
+   */
+  public generateSiteMapXML(): string {
+    return `<?xml version="1.0" encoding="UTF-8"?>
+  <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    ${this.siteMapEntry
+      .map(
+        (entry) => `<url>
+      <loc>${entry.loc}</loc>
+      <lastmod>${entry.lastmod}</lastmod>
+    </url>
+    `,
+      )
+      .join("")}
+  </urlset>`;
+  }
+}


### PR DESCRIPTION
Add the possibility to generate a `sitemap.xml` file to help search engine discover and index the content.

To do that add the `siteMapRoot` entry in the `.docConfig.json`
```json
"siteMapRoot": "http://example.com"
```
It will generate the sitemap file:
```xml
<?xml version="1.0" encoding="UTF-8"?>
  <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
    <url>
      <loc>http://example.com/Getting_Started/Home.html</loc>
      <lastmod>2024-09-24</lastmod>
    </url>
    <url>
      <loc>http://example.com/Getting_Started/Steps/Documentation_Files.html</loc>
      <lastmod>2024-09-24</lastmod>
    </url>
    ...
```