### PR TITLE
scripts: make ctrl & alt + click work as expected on site links

### DIFF
--- a/build/scripts/script.js
+++ b/build/scripts/script.js
@@ -815,6 +815,9 @@ function initializeSideBarLinks() {
       loadSidebarLink(link, { display: false, updateURL: false });
     }
     function onClick(evt) {
+      if (evt.ctrlKey || evt.altKey) {
+        return;
+      }
       evt.preventDefault();
       loadSidebarLink(link, { display: true, updateURL: true });
     }
@@ -851,6 +854,9 @@ function initializeContentLinks() {
         contentLink.removeEventListener("mouseover", onMouseOver);
       });
       function onClick(evt) {
+        if (evt.ctrlKey || evt.altKey) {
+          return;
+        }
         evt.preventDefault();
         loadSidebarLink(correspondingElt, {
           display: true,

--- a/build/scripts/script.js
+++ b/build/scripts/script.js
@@ -815,9 +815,22 @@ function initializeSideBarLinks() {
       loadSidebarLink(link, { display: false, updateURL: false });
     }
     function onClick(evt) {
-      if (evt.ctrlKey || evt.altKey) {
+      // Let browser handle modified clicks
+      if (evt.ctrlKey || evt.metaKey || evt.shiftKey || evt.altKey) {
         return;
       }
+
+      // Let browser handle non-left clicks (middle click, right click)
+      if (evt.button !== 0) {
+        return;
+      }
+
+      // Let browser handle links that open in new windows/tabs
+      const link = evt.currentTarget;
+      if (link.target && link.target !== "_self") {
+        return;
+      }
+
       evt.preventDefault();
       loadSidebarLink(link, { display: true, updateURL: true });
     }
@@ -854,9 +867,22 @@ function initializeContentLinks() {
         contentLink.removeEventListener("mouseover", onMouseOver);
       });
       function onClick(evt) {
-        if (evt.ctrlKey || evt.altKey) {
+        // Let browser handle modified clicks
+        if (evt.ctrlKey || evt.metaKey || evt.shiftKey || evt.altKey) {
           return;
         }
+
+        // Let browser handle non-left clicks (middle click, right click)
+        if (evt.button !== 0) {
+          return;
+        }
+
+        // Let browser handle links that open in new windows/tabs
+        const link = evt.currentTarget;
+        if (link.target && link.target !== "_self") {
+          return;
+        }
+
         evt.preventDefault();
         loadSidebarLink(correspondingElt, {
           display: true,


### PR DESCRIPTION
Links in our sidebar and table-of-content overrode the default browser click interactions to allow soft navigation.

This is nice excepted when a modifier key such as control or alt keys are maintained - as those are often relied on respectively to open a link in a new tab or a new window. With our current implementation, we would just soft-navigate on the same page.

I suppose those shortcuts depend on the browser. At first I just did exceptions for those two cases, but I grew uneasy because it didn't seem to me to be the right thing to do.

I ended up asking Claude what was the common approach for what I assume is a common problem, and it answered to me the much more exhaustive solution you see here.